### PR TITLE
Add heart rate card with realtime graph and history pages

### DIFF
--- a/lib/models/heart_rate.dart
+++ b/lib/models/heart_rate.dart
@@ -1,0 +1,15 @@
+class HeartRate {
+  final DateTime time;
+  final int bpm;
+
+  HeartRate({required this.time, required this.bpm});
+}
+
+/// Sample historical heart rate data
+final List<HeartRate> sampleHeartRates = [
+  HeartRate(time: DateTime.now().subtract(const Duration(minutes: 5)), bpm: 72),
+  HeartRate(time: DateTime.now().subtract(const Duration(minutes: 4)), bpm: 75),
+  HeartRate(time: DateTime.now().subtract(const Duration(minutes: 3)), bpm: 70),
+  HeartRate(time: DateTime.now().subtract(const Duration(minutes: 2)), bpm: 73),
+  HeartRate(time: DateTime.now().subtract(const Duration(minutes: 1)), bpm: 71),
+];

--- a/lib/pages/home/heart_rate_card.dart
+++ b/lib/pages/home/heart_rate_card.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:fl_chart/fl_chart.dart';
+
+import '../../models/heart_rate.dart';
+
+/// A card widget that displays heart rate information.
+///
+/// The first page shows a realtime heart rate chart, while subsequent pages
+/// display historical heart rate data.
+class HeartRateCard extends StatefulWidget {
+  final Stream<int> liveHeartRateStream;
+  final List<HeartRate> history;
+
+  const HeartRateCard({
+    Key? key,
+    required this.liveHeartRateStream,
+    required this.history,
+  }) : super(key: key);
+
+  @override
+  State<HeartRateCard> createState() => _HeartRateCardState();
+}
+
+class _HeartRateCardState extends State<HeartRateCard> {
+  final List<FlSpot> _liveData = [];
+
+  @override
+  void initState() {
+    super.initState();
+    widget.liveHeartRateStream.listen((bpm) {
+      setState(() {
+        final double x = _liveData.isEmpty ? 0 : _liveData.last.x + 1;
+        _liveData.add(FlSpot(x, bpm.toDouble()));
+        if (_liveData.length > 20) {
+          _liveData.removeAt(0);
+        }
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: SizedBox(
+        height: 200,
+        child: PageView(
+          children: [
+            _buildRealtimeChart(),
+            _buildHistoryList(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRealtimeChart() {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: LineChart(
+        LineChartData(
+          titlesData: FlTitlesData(show: false),
+          borderData: FlBorderData(show: false),
+          lineBarsData: [
+            LineChartBarData(
+              spots: _liveData,
+              isCurved: true,
+              dotData: FlDotData(show: false),
+              color: Colors.red,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHistoryList() {
+    return ListView.builder(
+      itemCount: widget.history.length,
+      itemBuilder: (context, index) {
+        final HeartRate hr = widget.history[index];
+        return ListTile(
+          leading: const Icon(Icons.favorite),
+          title: Text('${hr.bpm} bpm'),
+          subtitle: Text(hr.time.toString()),
+        );
+      },
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,18 @@
+name: goodboy
+
+description: A sample Flutter project with heart rate card.
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  fl_chart: ^0.63.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add HeartRate model for storing heart rate samples
- implement HeartRateCard widget with PageView containing realtime chart using fl_chart and historical data list
- configure fl_chart dependency in pubspec

## Testing
- `dart format .` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a168344b5883338ac7e88246bcd3d3